### PR TITLE
Changed delimiter in cryptdevices format from ';' to '+'

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,8 +21,8 @@ changelog=
 source=("multiencrypt_hook"
         "multiencrypt_install"
         "LICENSE")
-sha256sums=('105be328329e6352df601d64982d90d9cea7c8e7e630739bc69f42882c8523c6'
-            '504a694bc4c8c7153b5112356d498d05e652451a233ada2a575ac433c0bdd4de'
+sha256sums=('79a40a90695f687f9a4caa2cb2d62782cc2058aeda77055bd86d34f46389cac7  '
+            'dfe24de27bb872cae7dcf31a60f9dfd3ec2a85071757dcc687496d66739860cc'
             'c03cea027b4b40e4402fabd08557736727ec3d5bc54ad64ab6472de432198cad')
 validpgpkeys=()
 

--- a/multiencrypt_hook
+++ b/multiencrypt_hook
@@ -9,7 +9,7 @@ run_hook() {
         return 1
     fi
 
-    for devspec in $(echo "${cryptdevices}" | tr ';' '\n'); do
+    for devspec in $(echo "${cryptdevices}" | tr '+' '\n'); do
         [ -z "${devspec}" ] && continue
         
         IFS=: read cryptdev cryptname cryptoptions <<EOF

--- a/multiencrypt_install
+++ b/multiencrypt_install
@@ -33,7 +33,7 @@ passphrase once and tries  to reuse it for all the devices. If it fails on one
 device, it asks for a password again.
 
 Devices are specified on the kernel command line:
-cryptdevices=device1:dmname1[:options1];device2:dmname2[:options2];...
+cryptdevices=device1:dmname1[:options1]+device2:dmname2[:options2]+...
 
 Options are optional and separated by commata (,). Currently only one option is
 supported:


### PR DESCRIPTION
I'm not sure when this changed, but it seems that ';' is no longer a valid delimiter for separating devices, the content after the ; is dropped from the assignment to cryptdevices, causing the hook to operate on incomplete parameters. I've tried changing ';' to '+' in my kernel parameters and updated the hook accordingly, and I haven't run into any issues with decrypting multiple devices at boot.
